### PR TITLE
Removing Parent (activiti-build) from Activiti Dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,12 +2,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.activiti.build</groupId>
-    <artifactId>activiti-parent</artifactId>
-    <version>7.0.39</version>
-    <relativePath/>
-  </parent>
 
   <groupId>org.activiti.dependencies</groupId>
   <artifactId>activiti-dependencies</artifactId>
@@ -16,7 +10,7 @@
   <name>Activiti :: BOM (Bill of Materials)</name>
   <description>${project.name}</description>
   <url>http://activiti.org</url>
-  <inceptionYear>2010</inceptionYear>
+  <inceptionYear>2018</inceptionYear>
 
   <properties>
     <activiti-build.version>7.0.39</activiti-build.version>


### PR DESCRIPTION
removing the parent, because it is not needed and to be able to automate the checks with the enforcer.

fixes: https://github.com/Activiti/activiti-build/issues/42 

And related to: https://github.com/Activiti/Activiti/issues/2167