### PR TITLE
fix: (updatebot) push versions to activiti-examples master

### DIFF
--- a/.updatebot.yml
+++ b/.updatebot.yml
@@ -3,7 +3,7 @@ github:
   - name: activiti
     repositories:
     - name: activiti-examples
-      branch: develop
+      branch: master
     - name: activiti-cloud-runtime-bundle-service
       branch: develop
       useSinglePullRequest: true


### PR DESCRIPTION
It would be a good idea to cancel Jenkins pipeline to avoid triggering releases in downstream repos

Fixes Activiti/Activiti#2203
